### PR TITLE
Fixes #596. Hides all message tails when in details menu.

### DIFF
--- a/lib/layouts/widgets/message_widget/message_content/message_tail.dart
+++ b/lib/layouts/widgets/message_widget/message_content/message_tail.dart
@@ -6,16 +6,15 @@ class MessageTail extends StatelessWidget {
   final Color color;
   final Message message;
 
-  const MessageTail({Key key, @required this.message, this.color})
-      : super(key: key);
+  const MessageTail({Key key, @required this.message, this.color}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    bool hideTail = ((ModalRoute.of(context).settings.arguments ?? {"hideTail": false}) as Map)["hideTail"] ?? false;
+    if (hideTail) return Container();
     bool isFromMe = message?.isFromMe ?? true;
     return Stack(
-      alignment: isFromMe
-          ? AlignmentDirectional.bottomEnd
-          : AlignmentDirectional.bottomStart,
+      alignment: isFromMe ? AlignmentDirectional.bottomEnd : AlignmentDirectional.bottomStart,
       children: [
         Container(
           margin: EdgeInsets.only(
@@ -26,8 +25,7 @@ class MessageTail extends StatelessWidget {
           width: 20,
           height: 15,
           decoration: BoxDecoration(
-            color: color
-                ?? Theme.of(context).primaryColor,
+            color: color ?? Theme.of(context).primaryColor,
             borderRadius: BorderRadius.only(
               bottomRight: isFromMe ? Radius.zero : Radius.circular(12),
               bottomLeft: isFromMe ? Radius.circular(12) : Radius.zero,
@@ -41,8 +39,8 @@ class MessageTail extends StatelessWidget {
           decoration: BoxDecoration(
             color: Theme.of(context).backgroundColor,
             borderRadius: BorderRadius.only(
-              bottomRight:isFromMe ? Radius.zero : Radius.circular(8),
-              bottomLeft:isFromMe ? Radius.circular(8) : Radius.zero,
+              bottomRight: isFromMe ? Radius.zero : Radius.circular(8),
+              bottomLeft: isFromMe ? Radius.circular(8) : Radius.zero,
             ),
           ),
         ),

--- a/lib/layouts/widgets/message_widget/message_popup_holder.dart
+++ b/lib/layouts/widgets/message_widget/message_popup_holder.dart
@@ -48,6 +48,7 @@ class _MessagePopupHolderState extends State<MessagePopupHolder> {
     await Navigator.push(
       context,
       PageRouteBuilder(
+        settings: RouteSettings(arguments: {"hideTail": true},),
         transitionDuration: Duration(milliseconds: 0),
         pageBuilder: (context, animation, secondaryAnimation) {
           return MessageDetailsPopup(

--- a/lib/managers/current_chat.dart
+++ b/lib/managers/current_chat.dart
@@ -308,7 +308,7 @@ class CurrentChat {
     _stream.sink.add(null);
   }
 
-  /// Retreive all of the attachments associated with a chat
+  /// Retrieve all of the attachments associated with a chat
   Future<void> updateChatAttachments() async {
     chatAttachments = await Chat.getAttachments(chat);
   }


### PR DESCRIPTION
Real changes on message_tail.dart lines 13-14 and message_popup_holder.dart line 51. Change to current_chat.dart is just fixing a typo.

This pr hides the tail on all messages in the reactions/details popup (Fixes #596).

I have added an argument to details route that the MessageTail class accesses and displays no tail when this route is active.