### PR TITLE
Fixes #855

### DIFF
--- a/lib/layouts/conversation_view/camera_widget.dart
+++ b/lib/layouts/conversation_view/camera_widget.dart
@@ -78,136 +78,154 @@ class _CameraWidgetState extends State<CameraWidget> with WidgetsBindingObserver
           : 1 / (controller.value.previewSize.height / controller.value.previewSize.width),
       child: Stack(
         alignment: Alignment.topRight,
+        children: _buildCameraStack(context),
+      ),
+    );
+  }
+
+  List<Widget> _buildCameraStack(BuildContext context) {
+    if (SettingsManager().settings.redactedMode)
+      return [
+        Positioned.fill(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(20),
+            child: Container(
+              color: Theme.of(context).accentColor,
+              child: Center(
+                child: Text("Camera"),
+              ),
+            ),
+          ),
+        ),
+      ];
+    return [
+      Stack(
+        alignment: Alignment.bottomCenter,
         children: <Widget>[
-          Stack(
-            alignment: Alignment.bottomCenter,
-            children: <Widget>[
-              RotatedBox(
-                child: CameraPreview(controller),
-                quarterTurns: MediaQuery.of(context).orientation == Orientation.portrait ? 0 : 3,
-              ),
-              Padding(
-                padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).size.height / 30,
-                ),
-                child: FlatButton(
-                  color: Colors.transparent,
-                  onPressed: () async {
-                    XFile savedImage = await controller.takePicture();
-                    File file = new File(savedImage.path);
-
-                    // Fail if the file doesn't exist after taking the picture
-                    if (!file.existsSync()) {
-                      return this.showSnackbar('Failed to take picture! File improperly saved by Camera lib');
-                    }
-
-                    // Fail if the file size is equal to 0
-                    if (file.statSync().size == 0) {
-                      file.deleteSync();
-                      return this.showSnackbar('Failed to take picture! File was empty!');
-                    }
-
-                    // If all passes, add the attachment
-                    widget.addAttachment(file);
-                  },
-                  child: Icon(
-                    Icons.radio_button_checked,
-                    color: Colors.white,
-                    size: 30,
-                  ),
-                ),
-              )
-            ],
-          ),
-          Align(
-            alignment: Alignment.topLeft,
-            child: Padding(
-              padding: EdgeInsets.only(
-                bottom: MediaQuery.of(context).size.height / 30,
-              ),
-              child: FlatButton(
-                padding: EdgeInsets.only(left: 10),
-                minWidth: 30,
-                color: Colors.transparent,
-                onPressed: () async {
-                  String appDocPath = SettingsManager().appDocDir.path;
-                  File file = new File("$appDocPath/attachments/" + randomString(16) + ".png");
-                  await file.create(recursive: true);
-                  await MethodChannelInterface().invokeMethod("open-camera", {"path": file.path, "type": "camera"});
-
-                  if (!file.existsSync()) return;
-                  if (file.statSync().size == 0) {
-                    file.deleteSync();
-                    return;
-                  }
-
-                  widget.addAttachment(file);
-                },
-                child: Icon(
-                  Icons.fullscreen,
-                  color: Colors.white,
-                  size: 30,
-                ),
-              ),
-            ),
-          ),
-          Align(
-            alignment: Alignment.topCenter,
-            child: Padding(
-              padding: EdgeInsets.only(
-                bottom: MediaQuery.of(context).size.height / 30,
-              ),
-              child: FlatButton(
-                padding: EdgeInsets.all(0),
-                minWidth: 30,
-                color: Colors.transparent,
-                onPressed: () async {
-                  String appDocPath = SettingsManager().appDocDir.path;
-                  File file = new File("$appDocPath/attachments/" + randomString(16) + ".mp4");
-                  await file.create(recursive: true);
-                  await MethodChannelInterface().invokeMethod("open-camera", {"path": file.path, "type": "video"});
-
-                  if (!file.existsSync()) return;
-                  if (file.statSync().size == 0) {
-                    file.deleteSync();
-                    return;
-                  }
-
-                  widget.addAttachment(file);
-                },
-                child: Icon(
-                  Icons.videocam,
-                  color: Colors.white,
-                  size: 30,
-                ),
-              ),
-            ),
+          RotatedBox(
+            child: CameraPreview(controller),
+            quarterTurns: MediaQuery.of(context).orientation == Orientation.portrait ? 0 : 3,
           ),
           Padding(
             padding: EdgeInsets.only(
               bottom: MediaQuery.of(context).size.height / 30,
             ),
             child: FlatButton(
-              padding: EdgeInsets.only(right: 10),
-              minWidth: 30,
               color: Colors.transparent,
               onPressed: () async {
-                if (BlueBubblesTextField.of(context) == null) return;
+                XFile savedImage = await controller.takePicture();
+                File file = new File(savedImage.path);
 
-                BlueBubblesTextField.of(context).cameraIndex = (BlueBubblesTextField.of(context).cameraIndex - 1).abs();
+                // Fail if the file doesn't exist after taking the picture
+                if (!file.existsSync()) {
+                  return this.showSnackbar('Failed to take picture! File improperly saved by Camera lib');
+                }
 
-                await BlueBubblesTextField.of(context).initializeCameraController();
-                if (this.mounted) setState(() {});
+                // Fail if the file size is equal to 0
+                if (file.statSync().size == 0) {
+                  file.deleteSync();
+                  return this.showSnackbar('Failed to take picture! File was empty!');
+                }
+
+                // If all passes, add the attachment
+                widget.addAttachment(file);
               },
               child: Icon(
-                Icons.switch_camera,
+                Icons.radio_button_checked,
                 color: Colors.white,
                 size: 30,
               ),
             ),
-          ),
+          )
         ],
       ),
-    );
+      Align(
+        alignment: Alignment.topLeft,
+        child: Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).size.height / 30,
+          ),
+          child: FlatButton(
+            padding: EdgeInsets.only(left: 10),
+            minWidth: 30,
+            color: Colors.transparent,
+            onPressed: () async {
+              String appDocPath = SettingsManager().appDocDir.path;
+              File file = new File("$appDocPath/attachments/" + randomString(16) + ".png");
+              await file.create(recursive: true);
+              await MethodChannelInterface().invokeMethod("open-camera", {"path": file.path, "type": "camera"});
+
+              if (!file.existsSync()) return;
+              if (file.statSync().size == 0) {
+                file.deleteSync();
+                return;
+              }
+
+              widget.addAttachment(file);
+            },
+            child: Icon(
+              Icons.fullscreen,
+              color: Colors.white,
+              size: 30,
+            ),
+          ),
+        ),
+      ),
+      Align(
+        alignment: Alignment.topCenter,
+        child: Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).size.height / 30,
+          ),
+          child: FlatButton(
+            padding: EdgeInsets.all(0),
+            minWidth: 30,
+            color: Colors.transparent,
+            onPressed: () async {
+              String appDocPath = SettingsManager().appDocDir.path;
+              File file = new File("$appDocPath/attachments/" + randomString(16) + ".mp4");
+              await file.create(recursive: true);
+              await MethodChannelInterface().invokeMethod("open-camera", {"path": file.path, "type": "video"});
+
+              if (!file.existsSync()) return;
+              if (file.statSync().size == 0) {
+                file.deleteSync();
+                return;
+              }
+
+              widget.addAttachment(file);
+            },
+            child: Icon(
+              Icons.videocam,
+              color: Colors.white,
+              size: 30,
+            ),
+          ),
+        ),
+      ),
+      Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).size.height / 30,
+        ),
+        child: FlatButton(
+          padding: EdgeInsets.only(right: 10),
+          minWidth: 30,
+          color: Colors.transparent,
+          onPressed: () async {
+            if (BlueBubblesTextField.of(context) == null) return;
+
+            BlueBubblesTextField.of(context).cameraIndex = (BlueBubblesTextField.of(context).cameraIndex - 1).abs();
+
+            await BlueBubblesTextField.of(context).initializeCameraController();
+            if (this.mounted) setState(() {});
+          },
+          child: Icon(
+            Icons.switch_camera,
+            color: Colors.white,
+            size: 30,
+          ),
+        ),
+      ),
+    ];
   }
 }

--- a/lib/layouts/conversation_view/camera_widget.dart
+++ b/lib/layouts/conversation_view/camera_widget.dart
@@ -87,12 +87,15 @@ class _CameraWidgetState extends State<CameraWidget> with WidgetsBindingObserver
     if (SettingsManager().settings.redactedMode)
       return [
         Positioned.fill(
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(20),
-            child: Container(
-              color: Theme.of(context).accentColor,
-              child: Center(
-                child: Text("Camera"),
+          child: Padding(
+            padding: EdgeInsets.all(5),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(20),
+              child: Container(
+                color: Theme.of(context).accentColor,
+                child: Center(
+                  child: Text("Camera"),
+                ),
               ),
             ),
           ),

--- a/lib/layouts/conversation_view/text_field/attachments/list/attachment_list_item.dart
+++ b/lib/layouts/conversation_view/text_field/attachments/list/attachment_list_item.dart
@@ -54,28 +54,53 @@ class _AttachmentListItemState extends State<AttachmentListItem> {
 
   Widget getThumbnail() {
     if (preview != null) {
-      return InkWell(
-        child: Image.memory(
-          preview,
-          height: 100,
-          width: 100,
-          fit: BoxFit.cover,
-        ),
-        onTap: () async {
-          if (mime(widget.file.path) == null) return;
-          if (!this.mounted) return;
 
-          Attachment fakeAttachment = new Attachment(transferName: widget.file.path, mimeType: mimeType);
-          await Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (context) => AttachmentFullscreenViewer(
-                attachment: fakeAttachment,
-                showInteractions: false,
+      final bool hideAttachments = SettingsManager().settings.redactedMode && SettingsManager().settings.hideAttachments;
+      final bool hideAttachmentTypes =
+          SettingsManager().settings.redactedMode && SettingsManager().settings.hideAttachmentTypes;
+
+      final mimeType = mime(widget.file.path);
+
+      return Stack(children: <Widget>[
+        InkWell(
+          child: Image.memory(
+            preview,
+            height: 100,
+            width: 100,
+            fit: BoxFit.cover,
+          ),
+          onTap: () async {
+            if (mimeType == null) return;
+            if (!this.mounted) return;
+
+            Attachment fakeAttachment = new Attachment(transferName: widget.file.path, mimeType: mimeType);
+            await Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => AttachmentFullscreenViewer(
+                  attachment: fakeAttachment,
+                  showInteractions: false,
+                ),
+              ),
+            );
+          },
+        ),
+        if (hideAttachments)
+          Positioned.fill(
+            child: Container(
+              color: Theme.of(context).accentColor,
+            ),
+          ),
+        if (hideAttachments && !hideAttachmentTypes)
+          Positioned.fill(
+            child: Container(
+              alignment: Alignment.center,
+              child: Text(
+                mimeType,
+                textAlign: TextAlign.center,
               ),
             ),
-          );
-        },
-      );
+          ),
+      ]);
     } else {
       if (mimeType == null || mimeType.startsWith("video/") || mimeType.startsWith("image/")) {
         // If the preview is null and the mimetype is video or image,

--- a/lib/layouts/conversation_view/text_field/attachments/picker/attachment_picked.dart
+++ b/lib/layouts/conversation_view/text_field/attachments/picker/attachment_picked.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
 
 import 'package:bluebubbles/layouts/conversation_view/text_field/blue_bubbles_text_field.dart';
+import 'package:bluebubbles/managers/settings_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:mime_type/mime_type.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 class AttachmentPicked extends StatefulWidget {
@@ -43,6 +45,9 @@ class _AttachmentPickedState extends State<AttachmentPicked> with AutomaticKeepA
   @override
   Widget build(BuildContext context) {
     super.build(context);
+    final bool hideAttachments = SettingsManager().settings.redactedMode && SettingsManager().settings.hideAttachments;
+    final bool hideAttachmentTypes =
+        SettingsManager().settings.redactedMode && SettingsManager().settings.hideAttachmentTypes;
     return image != null
         ? AnimatedContainer(
             duration: Duration(milliseconds: 250),
@@ -52,11 +57,31 @@ class _AttachmentPickedState extends State<AttachmentPicked> with AutomaticKeepA
               children: <Widget>[
                 ClipRRect(
                   borderRadius: BorderRadius.circular(20),
-                  child: Image.memory(
-                    image,
-                    fit: BoxFit.cover,
-                    width: 150,
-                    height: 150,
+                  child: Stack(
+                    children: <Widget>[
+                      Image.memory(
+                        image,
+                        fit: BoxFit.cover,
+                        width: 150,
+                        height: 150,
+                      ),
+                      if (hideAttachments)
+                        Positioned.fill(
+                          child: Container(
+                            color: Theme.of(context).accentColor,
+                          ),
+                        ),
+                      if (hideAttachments && !hideAttachmentTypes)
+                        Positioned.fill(
+                          child: Container(
+                            alignment: Alignment.center,
+                            child: Text(
+                              mime(path),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
                 ),
                 if (containsThis)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -155,20 +155,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.1.0"
+  cached_network_image:
+    dependency: transitive
+    description:
+      name: cached_network_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.3"
   camera:
     dependency: "direct main"
     description:
       name: camera
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0+4"
-  camera_platform_interface:
-    dependency: transitive
-    description:
-      name: camera_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.5.0"
+    version: "0.5.8+11"
   characters:
     dependency: transitive
     description:
@@ -281,13 +281,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.2"
-  cross_file:
-    dependency: transitive
-    description:
-      name: cross_file
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.0"
   crypto:
     dependency: transitive
     description:
@@ -303,7 +296,7 @@ packages:
     source: hosted
     version: "0.16.2"
   cupertino_icons:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
@@ -391,6 +384,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   flutter_colorpicker:
     dependency: "direct main"
     description:
@@ -446,7 +453,7 @@ packages:
       name: flutter_map
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.0"
+    version: "0.9.0"
   flutter_markdown:
     dependency: "direct main"
     description:
@@ -556,14 +563,14 @@ packages:
       name: image_gallery_saver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "1.6.6"
   image_size_getter:
     dependency: "direct main"
     description:
       name: image_size_getter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.1"
   intent:
     dependency: "direct main"
     description:
@@ -718,6 +725,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.12"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   package_config:
     dependency: transitive
     description:
@@ -794,14 +808,14 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0+2"
+    version: "5.0.1+1"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.1"
   petitparser:
     dependency: transitive
     description:
@@ -993,6 +1007,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.3"
+  simple_router:
+    dependency: "direct main"
+    description:
+      name: simple_router
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1186,7 +1207,7 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "0.10.12+5"
   video_player_platform_interface:
     dependency: transitive
     description:
@@ -1280,4 +1301,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.22.0 <2.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -155,20 +155,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.1.0"
-  cached_network_image:
-    dependency: transitive
-    description:
-      name: cached_network_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.3.3"
   camera:
     dependency: "direct main"
     description:
       name: camera
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.8+11"
+    version: "0.7.0+4"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.0"
   characters:
     dependency: transitive
     description:
@@ -281,6 +281,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   crypto:
     dependency: transitive
     description:
@@ -296,7 +303,7 @@ packages:
     source: hosted
     version: "0.16.2"
   cupertino_icons:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
@@ -384,20 +391,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_blurhash:
-    dependency: transitive
-    description:
-      name: flutter_blurhash
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
-  flutter_cache_manager:
-    dependency: transitive
-    description:
-      name: flutter_cache_manager
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   flutter_colorpicker:
     dependency: "direct main"
     description:
@@ -453,7 +446,7 @@ packages:
       name: flutter_map
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0"
+    version: "0.11.0"
   flutter_markdown:
     dependency: "direct main"
     description:
@@ -563,14 +556,14 @@ packages:
       name: image_gallery_saver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.6"
+    version: "1.6.8"
   image_size_getter:
     dependency: "direct main"
     description:
       name: image_size_getter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.3.0"
   intent:
     dependency: "direct main"
     description:
@@ -725,13 +718,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.12"
-  octo_image:
-    dependency: transitive
-    description:
-      name: octo_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.0"
   package_config:
     dependency: transitive
     description:
@@ -808,14 +794,14 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1+1"
+    version: "5.1.0+2"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   petitparser:
     dependency: transitive
     description:
@@ -1007,13 +993,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.3"
-  simple_router:
-    dependency: "direct main"
-    description:
-      name: simple_router
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.0+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1207,7 +1186,7 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.12+5"
+    version: "1.0.1"
   video_player_platform_interface:
     dependency: transitive
     description:
@@ -1301,4 +1280,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.20.0 <2.0.0"
+  flutter: ">=1.22.0 <2.0.0"


### PR DESCRIPTION
Fixes #855.

The logic is the same as redacted mode for normal files in the conversation view, but I have included it below anyway.

If redacted mode is enabled:
    If hideAttachments is enabled:
        if hideAttachmentTypes is enabled: show blank square
        else: show mimeType in blank square

To create this, I basically make a stack with elements being added in based on the above logic. The original widget is the first element of the stack so it is covered by any subsequent widgets.

## MORE STUFF
- I also made the same changes to the file views in the attachment picker.
- The camera widget hides in redacted mode