### PR TITLE
Improve all timestamps

### DIFF
--- a/lib/helpers/utils.dart
+++ b/lib/helpers/utils.dart
@@ -176,12 +176,15 @@ bool sameSender(Message first, Message second) {
 }
 
 String buildDate(DateTime dateTime) {
+  if (dateTime == null || dateTime.millisecondsSinceEpoch == 0) return "";
   String time = new intl.DateFormat.jm().format(dateTime);
   String date;
   if (dateTime.isToday()) {
     date = time;
   } else if (dateTime.isYesterday()) {
     date = "Yesterday";
+  } else if (DateTime.now().difference(dateTime.toLocal()).inDays <= 7) {
+    date = intl.DateFormat("EEEE").format(dateTime);
   } else {
     date = "${dateTime.month.toString()}/${dateTime.day.toString()}/${dateTime.year.toString()}";
   }
@@ -499,17 +502,6 @@ String getServerAddress({String address}) {
   }
 
   return serverAddress;
-}
-
-String dateToShortString(DateTime timestamp) {
-  if (timestamp == null || timestamp.millisecondsSinceEpoch == 0) return "";
-  if (timestamp.isToday()) {
-    return new intl.DateFormat.jm().format(timestamp);
-  } else if (timestamp.isYesterday()) {
-    return "Yesterday";
-  } else {
-    return "${timestamp.month.toString()}/${timestamp.day.toString()}/${timestamp.year.toString()}";
-  }
 }
 
 Future<String> getDeviceName() async {

--- a/lib/layouts/conversation_list/conversation_tile.dart
+++ b/lib/layouts/conversation_list/conversation_tile.dart
@@ -380,9 +380,9 @@ class _ConversationTileState extends State<ConversationTile> with AutomaticKeepA
     return Padding(padding: EdgeInsets.only(top: 2, right: 2), child: avatar);
   }
 
-  Widget buildDate() => Center(
+  Widget _buildDate() => Center(
           child: Text(
-        widget.chat.getDateText(),
+        buildDate(widget.chat.latestMessageDate),
         textAlign: TextAlign.right,
         style: Theme.of(context)
             .textTheme
@@ -530,7 +530,7 @@ class __CupertinoState extends State<_Cupertino> {
                         children: <Widget>[
                           Container(
                             padding: EdgeInsets.only(right: 2),
-                            child: widget.parent.buildDate(),
+                            child: widget.parent._buildDate(),
                           ),
                           Icon(
                             SettingsManager().settings.skin == Skins.IOS
@@ -666,7 +666,7 @@ class _Material extends StatelessWidget {
                     ),
                   Container(
                     padding: EdgeInsets.only(right: 2, left: 2),
-                    child: parent.buildDate(),
+                    child: parent._buildDate(),
                   ),
                 ],
               ),
@@ -751,7 +751,7 @@ class _Samsung extends StatelessWidget {
                     ),
                   Container(
                     padding: EdgeInsets.only(right: 2, left: 2),
-                    child: parent.buildDate(),
+                    child: parent._buildDate(),
                   ),
                 ],
               ),

--- a/lib/layouts/search/search_view.dart
+++ b/lib/layouts/search/search_view.dart
@@ -324,7 +324,7 @@ class SearchViewState extends State<SearchView> with TickerProviderStateMixin {
                                     crossAxisAlignment: CrossAxisAlignment.start,
                                     mainAxisAlignment: MainAxisAlignment.start,
                                     children: [
-                                      Text("${dateToShortString(message.dateCreated)}",
+                                      Text("${buildDate(message.dateCreated)}",
                                           style: Theme.of(context).textTheme.subtitle1.apply(fontSizeDelta: -2)),
                                       Container(height: 5.0),
                                       Text(chat?.title, style: Theme.of(context).textTheme.bodyText1),

--- a/lib/layouts/widgets/message_widget/message_content/message_time_stamp.dart
+++ b/lib/layouts/widgets/message_widget/message_content/message_time_stamp.dart
@@ -21,11 +21,8 @@ class MessageTimeStamp extends StatelessWidget {
         builder: (context, snapshot) {
           double offset = CurrentChat.of(context)?.timeStampOffset;
           String text = DateFormat('h:mm a').format(message.dateCreated).toLowerCase();
-          if (message.dateCreated.isYesterday()) {
-            text = "Yesterday${singleLine ? ", " : "\n"}$text";
-          } else if (!message.dateCreated.isToday()) {
-            DateFormat formatter = DateFormat('MMMd');
-            String formatted = formatter.format(message.dateCreated);
+          if (!message.dateCreated.isToday()) {
+            String formatted = buildDate(message.dateCreated);
             text = "$formatted${singleLine ? " " : "\n"}$text";
           }
 

--- a/lib/layouts/widgets/message_widget/message_content/message_time_stamp_separator.dart
+++ b/lib/layouts/widgets/message_widget/message_content/message_time_stamp_separator.dart
@@ -21,17 +21,10 @@ class MessageTimeStampSeparator extends StatelessWidget {
     if (newerMessage != null &&
         (!isEmptyString(message.fullText) || message.hasAttachments) &&
         withinTimeThreshold(message, newerMessage, threshold: 30)) {
+
       DateTime timeOfnewerMessage = newerMessage.dateCreated;
       String time = new DateFormat.jm().format(timeOfnewerMessage);
-      String date;
-      if (newerMessage.dateCreated.isToday()) {
-        date = "Today";
-      } else if (newerMessage.dateCreated.isYesterday()) {
-        date = "Yesterday";
-      } else {
-        date =
-            "${timeOfnewerMessage.month.toString()}/${timeOfnewerMessage.day.toString()}/${timeOfnewerMessage.year.toString()}";
-      }
+      String date = timeOfnewerMessage.isToday() ? "Today" : buildDate(timeOfnewerMessage);
       return {"date": date, "time": time};
     } else {
       return null;

--- a/lib/repository/models/chat.dart
+++ b/lib/repository/models/chat.dart
@@ -14,7 +14,6 @@ import 'package:bluebubbles/repository/models/attachment.dart';
 import 'package:bluebubbles/socket_manager.dart';
 import 'package:faker/faker.dart';
 import 'package:flutter/widgets.dart';
-import 'package:intl/intl.dart';
 import 'package:metadata_fetch/metadata_fetch.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -236,14 +235,7 @@ class Chat {
   }
 
   String getDateText() {
-    if (this.latestMessageDate == null || this.latestMessageDate.millisecondsSinceEpoch == 0) return "";
-    if (this.latestMessageDate.isToday()) {
-      return new DateFormat.jm().format(this.latestMessageDate);
-    } else if (this.latestMessageDate.isYesterday()) {
-      return "Yesterday";
-    } else {
-      return "${this.latestMessageDate.month.toString()}/${this.latestMessageDate.day.toString()}/${this.latestMessageDate.year.toString()}";
-    }
+    return buildDate(this.latestMessageDate);
   }
 
   Future<Chat> update() async {


### PR DESCRIPTION
The goal of this pr is to improve the way timestamps are displayed throughout the app. This has been done in several ways.
- The building of date strings has been consolidated to one function in `utils.dart` and this is used wherever possible.
- All dates are displayed as follows
   - If today, "Today"
  - If yesterday, "Yesterday"
  - If within a week, "Thursday" (obviously this is an example. In reality it would be the day of the timestamp)
  - If more than a week ago, "05/14/2021" (again, an example)
- In places where "Today" is not displayed, the actual time (e.g. "4:37 PM") is displayed

For the most part, the changes reflect actual iMessage. The one exception that I've noticed is our displaying of the date in addition to the time in the individual message timestamps shown when swiped to the side in the conversation view. However, our current implementation is far superior to that of iMessage so I left this as is.

## Screenshots
### Conversation List
![Screenshot_1622618138](https://user-images.githubusercontent.com/35714943/120441369-53b73580-c339-11eb-802c-084358b7a3b4.png)
## Message timestamps
![Screenshot_1622618149](https://user-images.githubusercontent.com/35714943/120441373-544fcc00-c339-11eb-9d7f-968961c15eb2.png)
## More message timestamps
![Screenshot_1622618164](https://user-images.githubusercontent.com/35714943/120441374-54e86280-c339-11eb-862b-75e01aa19ab2.png)
## Old timestamps and an old message separator
![Screenshot_1622618233](https://user-images.githubusercontent.com/35714943/120441376-5580f900-c339-11eb-9415-13c38009cab2.png)



