### PR TITLE
Fix contact avatar showing the other person instead of the one who actually sent the tapback

### DIFF
--- a/lib/layouts/widgets/message_widget/reaction_detail_widget.dart
+++ b/lib/layouts/widgets/message_widget/reaction_detail_widget.dart
@@ -55,7 +55,7 @@ class _ReactionDetailWidgetState extends State<ReactionDetailWidget> {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 25.0, vertical: 10),
           child: ContactAvatarWidget(
-            handle: widget.handle,
+            handle: widget.message.isFromMe ? null : widget.handle,
             borderThickness: 0.1,
             editable: false,
           ),


### PR DESCRIPTION
Fixes #908.

Tried to get "my" contact photo in there but I didn't see a way to do this, especially because in a group chat "my" handle does not come up in the list of participants, making me think that "my" contact details aren't sent from the iMac? Not too sure but for now it will display a "Y" as the avatar.