### PR TITLE
Add support for .heic images in fullscreen mode and show a proper error when the image fails to load

### DIFF
--- a/lib/layouts/image_viewer/image_viewer.dart
+++ b/lib/layouts/image_viewer/image_viewer.dart
@@ -72,10 +72,11 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
   }
 
   Future<void> initBytes() async {
-    bytes = await widget.file.readAsBytes();
     if (widget.attachment.mimeType == "image/heic") {
       bytes = await FlutterImageCompress.compressWithFile(widget.file.absolute.path,
           quality: 100);
+    } else {
+      bytes = await widget.file.readAsBytes();
     }
     if (this.mounted) setState(() {});
   }
@@ -279,7 +280,7 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
                         return loader;
                       },
                       loadFailedChild: Center(
-                          child: Text("Failed to load image",
+                          child: Text("Failed to display image",
                               style: TextStyle(fontSize: 16, color: Colors.white))
                       )
                     )

--- a/lib/layouts/image_viewer/image_viewer.dart
+++ b/lib/layouts/image_viewer/image_viewer.dart
@@ -12,6 +12,7 @@ import 'package:bluebubbles/repository/models/attachment.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:photo_view/photo_view.dart';
 
 class ImageViewer extends StatefulWidget {
@@ -72,6 +73,10 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
 
   Future<void> initBytes() async {
     bytes = await widget.file.readAsBytes();
+    if (widget.attachment.mimeType == "image/heic") {
+      bytes = await FlutterImageCompress.compressWithFile(widget.file.absolute.path,
+          quality: 100);
+    }
     if (this.mounted) setState(() {});
   }
 
@@ -273,6 +278,10 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
                       loadingBuilder: (BuildContext context, ImageChunkEvent ev) {
                         return loader;
                       },
+                      loadFailedChild: Center(
+                          child: Text("Failed to load image",
+                              style: TextStyle(fontSize: 16, color: Colors.white))
+                      )
                     )
                   : loader,
               overlay


### PR DESCRIPTION
Fixes #911.

Not the best solution because .heic will still appear slightly compressed in the fullscreen viewer but its better than not being able to see the image at all.