### PR TITLE
Disable creating new chats if the server is on Big Sur or up

### DIFF
--- a/lib/layouts/conversation_list/conversation_list.dart
+++ b/lib/layouts/conversation_list/conversation_list.dart
@@ -228,16 +228,21 @@ class _ConversationListState extends State<ConversationList> {
     ];
   }
 
-  void openNewChatCreator() {
-    Navigator.of(context).push(
-      CupertinoPageRoute(
-        builder: (BuildContext context) {
-          return ConversationView(
-            isCreator: true,
-          );
-        },
-      ),
-    );
+  void openNewChatCreator() async {
+    if ((await SettingsManager().getMacOSVersion()) < 11) {
+      Navigator.of(context).push(
+        CupertinoPageRoute(
+          builder: (BuildContext context) {
+            return ConversationView(
+              isCreator: true,
+            );
+          },
+        ),
+      );
+    } else {
+      final snackBar = SnackBar(content: Text('Creating chats is currently not supported on MacOS 11 (Big Sur) and up!'));
+      Scaffold.of(context).showSnackBar(snackBar);
+    }
   }
 
   void sortChats() {
@@ -328,11 +333,16 @@ class _ConversationListState extends State<ConversationList> {
         )
       : Container();
 
-  FloatingActionButton buildFloatinActionButton() {
-    return FloatingActionButton(
-        backgroundColor: Theme.of(context).primaryColor,
-        child: Icon(Icons.message, color: Colors.white, size: 25),
-        onPressed: openNewChatCreator);
+  FutureBuilder buildFloatinActionButton() {
+    return FutureBuilder<int>(
+      future: SettingsManager().getMacOSVersion(),
+      builder: (context, snapshot) {
+        return FloatingActionButton(
+            backgroundColor: Theme.of(context).primaryColor.withOpacity(snapshot.hasData && snapshot.data >= 11 ? 0.5 : 1),
+            child: Icon(Icons.message, color: Colors.white, size: 25),
+            onPressed: openNewChatCreator);
+      }
+    );
   }
 
   List<Widget> getConnectionIndicatorWidgets() {

--- a/lib/layouts/conversation_list/conversation_list.dart
+++ b/lib/layouts/conversation_list/conversation_list.dart
@@ -229,20 +229,17 @@ class _ConversationListState extends State<ConversationList> {
   }
 
   void openNewChatCreator() async {
-    if ((await SettingsManager().getMacOSVersion()) < 11) {
-      Navigator.of(context).push(
-        CupertinoPageRoute(
-          builder: (BuildContext context) {
-            return ConversationView(
-              isCreator: true,
-            );
-          },
-        ),
-      );
-    } else {
-      final snackBar = SnackBar(content: Text('Creating chats is currently not supported on MacOS 11 (Big Sur) and up!'));
-      Scaffold.of(context).showSnackBar(snackBar);
-    }
+    bool shouldShowSnackbar = (await SettingsManager().getMacOSVersion()) >= 11;
+    Navigator.of(context).push(
+      CupertinoPageRoute(
+        builder: (BuildContext context) {
+          return ConversationView(
+            isCreator: true,
+            showSnackbar: shouldShowSnackbar,
+          );
+        },
+      ),
+    );
   }
 
   void sortChats() {
@@ -333,16 +330,11 @@ class _ConversationListState extends State<ConversationList> {
         )
       : Container();
 
-  FutureBuilder buildFloatinActionButton() {
-    return FutureBuilder<int>(
-      future: SettingsManager().getMacOSVersion(),
-      builder: (context, snapshot) {
-        return FloatingActionButton(
-            backgroundColor: Theme.of(context).primaryColor.withOpacity(snapshot.hasData && snapshot.data >= 11 ? 0.5 : 1),
-            child: Icon(Icons.message, color: Colors.white, size: 25),
-            onPressed: openNewChatCreator);
-      }
-    );
+  FloatingActionButton buildFloatinActionButton() {
+    return FloatingActionButton(
+        backgroundColor: Theme.of(context).primaryColor,
+        child: Icon(Icons.message, color: Colors.white, size: 25),
+        onPressed: openNewChatCreator);
   }
 
   List<Widget> getConnectionIndicatorWidgets() {

--- a/lib/layouts/conversation_view/conversation_view.dart
+++ b/lib/layouts/conversation_view/conversation_view.dart
@@ -48,6 +48,7 @@ class ConversationView extends StatefulWidget {
     this.onMessagesViewComplete,
     this.selected,
     this.type = ChatSelectorTypes.ALL,
+    this.showSnackbar = false,
   }) : super(key: key);
 
   final Chat chat;
@@ -58,6 +59,7 @@ class ConversationView extends StatefulWidget {
   final bool isCreator;
   final MessageBloc customMessageBloc;
   final Function onMessagesViewComplete;
+  final bool showSnackbar;
 
   @override
   ConversationViewState createState() => ConversationViewState();
@@ -294,6 +296,11 @@ class ConversationViewState extends State<ConversationView> with ConversationVie
     if (messageBloc == null) {
       messageBloc = initMessageBloc();
       messageBloc.getMessages();
+    }
+
+    if (widget.showSnackbar) {
+      final snackBar = SnackBar(content: Text('Support for creating chats is currently limited on MacOS 11 (Big Sur) and up due to limitations imposed by Apple!'));
+      Scaffold.of(context).showSnackBar(snackBar);
     }
 
     Widget textField = BlueBubblesTextField(

--- a/lib/layouts/conversation_view/conversation_view.dart
+++ b/lib/layouts/conversation_view/conversation_view.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:get/get.dart';
+import 'package:bluebubbles/helpers/utils.dart';
 import 'package:bluebubbles/action_handler.dart';
 import 'package:bluebubbles/blocs/chat_bloc.dart';
 import 'package:bluebubbles/blocs/message_bloc.dart';
@@ -20,6 +20,7 @@ import 'package:bluebubbles/managers/queue_manager.dart';
 import 'package:bluebubbles/managers/settings_manager.dart';
 import 'package:bluebubbles/repository/models/chat.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:keyboard_attachable/keyboard_attachable.dart';
@@ -113,6 +114,12 @@ class ConversationViewState extends State<ConversationView> with ConversationVie
         await _chat.getParticipants();
         currentChat.chat = _chat;
         if (this.mounted) setState(() {});
+      }
+    });
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (widget.showSnackbar) {
+        showSnackbar('Warning', 'Support for creating chats is currently limited on MacOS 11 (Big Sur) and up due to limitations imposed by Apple');
       }
     });
   }
@@ -297,11 +304,6 @@ class ConversationViewState extends State<ConversationView> with ConversationVie
     if (messageBloc == null) {
       messageBloc = initMessageBloc();
       messageBloc.getMessages();
-    }
-
-    if (widget.showSnackbar) {
-      final snackBar = SnackBar(content: Text('Support for creating chats is currently limited on MacOS 11 (Big Sur) and up due to limitations imposed by Apple!'));
-      Scaffold.of(context).showSnackBar(snackBar);
     }
 
     Widget textField = BlueBubblesTextField(

--- a/lib/layouts/widgets/message_widget/message_details_popup.dart
+++ b/lib/layouts/widgets/message_widget/message_details_popup.dart
@@ -375,119 +375,81 @@ class MessageDetailsPopupState extends State<MessageDetailsPopup> with TickerPro
           ),
         ),
       if (widget.currentChat.chat.isGroup() && !widget.message.isFromMe && dmChat == null)
-        FutureBuilder<int>(
-          future: SettingsManager().getMacOSVersion(),
-          builder: (context, snapshot) {
-            return AnimatedSwitcher(
-              duration: Duration(milliseconds: 500),
-              child: snapshot.hasData && snapshot.data < 11 ? Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  splashColor: Colors.transparent,
-                  highlightColor: Colors.transparent,
-                  onTap: () async {
-                    String address = widget.message.handle.address;
-                    Contact contact = ContactManager().getCachedContactSync(address);
-                    UniqueContact uniqueContact;
-                    if (contact == null) {
-                      uniqueContact = UniqueContact(address: address, displayName: (await formatPhoneNumber(address)));
-                    } else {
-                      uniqueContact = UniqueContact(address: address, displayName: contact.displayName ?? address);
-                    }
-                    Navigator.pushReplacement(
-                      context,
-                      cupertino.CupertinoPageRoute(
-                        builder: (BuildContext context) {
-                          return ConversationView(
-                            isCreator: true,
-                            selected: [uniqueContact],
-                          );
-                        },
-                      ),
+        Material(
+          color: Colors.transparent,
+          child: InkWell(
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            onTap: () async {
+              bool shouldShowSnackbar = (await SettingsManager().getMacOSVersion()) >= 11;
+              String address = widget.message.handle.address;
+              Contact contact = ContactManager().getCachedContactSync(address);
+              UniqueContact uniqueContact;
+              if (contact == null) {
+                uniqueContact = UniqueContact(address: address, displayName: (await formatPhoneNumber(address)));
+              } else {
+                uniqueContact = UniqueContact(address: address, displayName: contact.displayName ?? address);
+              }
+              Navigator.pushReplacement(
+                context,
+                cupertino.CupertinoPageRoute(
+                  builder: (BuildContext context) {
+                    return ConversationView(
+                      isCreator: true,
+                      selected: [uniqueContact],
+                      showSnackbar: shouldShowSnackbar,
                     );
                   },
-                  child: ListTile(
-                    title: Text(
-                      "Start Conversation",
-                      style: Theme.of(context).textTheme.bodyText1,
-                    ),
-                    trailing: Icon(
-                      Icons.message,
-                      color: Theme.of(context).textTheme.bodyText1.color,
-                    ),
-                  ),
                 ),
-              ) : Material(
-                color: Colors.transparent,
-                child: ListTile(
-                  title: Text(
-                    "Start Conversation",
-                    style: Theme.of(context).textTheme.bodyText1
-                        .copyWith(color: Theme.of(context).textTheme.bodyText1.color.withOpacity(0.5)),
-                  ),
-                  trailing: Icon(
-                    Icons.message,
-                    color: Theme.of(context).textTheme.bodyText1.color.withOpacity(0.5),
-                  ),
-                ),
+              );
+            },
+            child: ListTile(
+              title: Text(
+                "Start Conversation",
+                style: Theme.of(context).textTheme.bodyText1,
               ),
-            );
-          }
-        ),
-      FutureBuilder<int>(
-        future: SettingsManager().getMacOSVersion(),
-        builder: (context, snapshot) {
-          return AnimatedSwitcher(
-            duration: Duration(milliseconds: 500),
-            child: snapshot.hasData && snapshot.data < 11 ? Material(
-              color: Colors.transparent,
-              child: InkWell(
-                onTap: () async {
-                  Navigator.pushReplacement(
-                    context,
-                    cupertino.CupertinoPageRoute(
-                      builder: (BuildContext context) {
-                        List<File> existingAttachments = [];
-                        if (!widget.message.isUrlPreview()) {
-                          existingAttachments =
-                              widget.message.attachments.map((attachment) => File(attachment.getPath())).toList();
-                        }
-                        return ConversationView(
-                          isCreator: true,
-                          existingText: widget.message.text,
-                          existingAttachments: existingAttachments,
-                        );
-                      },
-                    ),
-                  );
-                },
-                child: ListTile(
-                  title: Text(
-                    "Forward",
-                    style: Theme.of(context).textTheme.bodyText1,
-                  ),
-                  trailing: Icon(
-                    Icons.forward,
-                    color: Theme.of(context).textTheme.bodyText1.color,
-                  ),
-                ),
-              ),
-            ) : Material(
-              color: Colors.transparent,
-              child: ListTile(
-                title: Text(
-                  "Forward",
-                  style: Theme.of(context).textTheme.bodyText1
-                      .copyWith(color: Theme.of(context).textTheme.bodyText1.color.withOpacity(0.5)),
-                ),
-                trailing: Icon(
-                  Icons.forward,
-                  color: Theme.of(context).textTheme.bodyText1.color.withOpacity(0.5),
-                ),
+              trailing: Icon(
+                Icons.message,
+                color: Theme.of(context).textTheme.bodyText1.color,
               ),
             ),
-          );
-        }
+          ),
+        ),
+      Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: () async {
+            bool shouldShowSnackbar = (await SettingsManager().getMacOSVersion()) >= 11;
+            Navigator.pushReplacement(
+              context,
+              cupertino.CupertinoPageRoute(
+                builder: (BuildContext context) {
+                  List<File> existingAttachments = [];
+                  if (!widget.message.isUrlPreview()) {
+                    existingAttachments =
+                        widget.message.attachments.map((attachment) => File(attachment.getPath())).toList();
+                  }
+                  return ConversationView(
+                    isCreator: true,
+                    existingText: widget.message.text,
+                    existingAttachments: existingAttachments,
+                    showSnackbar: shouldShowSnackbar,
+                  );
+                },
+              ),
+            );
+          },
+          child: ListTile(
+            title: Text(
+              "Forward",
+              style: Theme.of(context).textTheme.bodyText1,
+            ),
+            trailing: Icon(
+              Icons.forward,
+              color: Theme.of(context).textTheme.bodyText1.color,
+            ),
+          ),
+        ),
       ),
       Material(
         color: Colors.transparent,

--- a/lib/layouts/widgets/message_widget/message_details_popup.dart
+++ b/lib/layouts/widgets/message_widget/message_details_popup.dart
@@ -375,77 +375,119 @@ class MessageDetailsPopupState extends State<MessageDetailsPopup> with TickerPro
           ),
         ),
       if (widget.currentChat.chat.isGroup() && !widget.message.isFromMe && dmChat == null)
-        Material(
-          color: Colors.transparent,
-          child: InkWell(
-            splashColor: Colors.transparent,
-            highlightColor: Colors.transparent,
-            onTap: () async {
-              String address = widget.message.handle.address;
-              Contact contact = ContactManager().getCachedContactSync(address);
-              UniqueContact uniqueContact;
-              if (contact == null) {
-                uniqueContact = UniqueContact(address: address, displayName: (await formatPhoneNumber(address)));
-              } else {
-                uniqueContact = UniqueContact(address: address, displayName: contact.displayName ?? address);
-              }
-              Navigator.pushReplacement(
-                context,
-                cupertino.CupertinoPageRoute(
-                  builder: (BuildContext context) {
-                    return ConversationView(
-                      isCreator: true,
-                      selected: [uniqueContact],
+        FutureBuilder<int>(
+          future: SettingsManager().getMacOSVersion(),
+          builder: (context, snapshot) {
+            return AnimatedSwitcher(
+              duration: Duration(milliseconds: 500),
+              child: snapshot.hasData && snapshot.data < 11 ? Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  splashColor: Colors.transparent,
+                  highlightColor: Colors.transparent,
+                  onTap: () async {
+                    String address = widget.message.handle.address;
+                    Contact contact = ContactManager().getCachedContactSync(address);
+                    UniqueContact uniqueContact;
+                    if (contact == null) {
+                      uniqueContact = UniqueContact(address: address, displayName: (await formatPhoneNumber(address)));
+                    } else {
+                      uniqueContact = UniqueContact(address: address, displayName: contact.displayName ?? address);
+                    }
+                    Navigator.pushReplacement(
+                      context,
+                      cupertino.CupertinoPageRoute(
+                        builder: (BuildContext context) {
+                          return ConversationView(
+                            isCreator: true,
+                            selected: [uniqueContact],
+                          );
+                        },
+                      ),
                     );
                   },
+                  child: ListTile(
+                    title: Text(
+                      "Start Conversation",
+                      style: Theme.of(context).textTheme.bodyText1,
+                    ),
+                    trailing: Icon(
+                      Icons.message,
+                      color: Theme.of(context).textTheme.bodyText1.color,
+                    ),
+                  ),
                 ),
-              );
-            },
-            child: ListTile(
-              title: Text(
-                "Start Conversation",
-                style: Theme.of(context).textTheme.bodyText1,
-              ),
-              trailing: Icon(
-                Icons.message,
-                color: Theme.of(context).textTheme.bodyText1.color,
-              ),
-            ),
-          ),
-        ),
-      Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: () {
-            Navigator.pushReplacement(
-              context,
-              cupertino.CupertinoPageRoute(
-                builder: (BuildContext context) {
-                  List<File> existingAttachments = [];
-                  if (!widget.message.isUrlPreview()) {
-                    existingAttachments =
-                        widget.message.attachments.map((attachment) => File(attachment.getPath())).toList();
-                  }
-                  return ConversationView(
-                    isCreator: true,
-                    existingText: widget.message.text,
-                    existingAttachments: existingAttachments,
-                  );
-                },
+              ) : Material(
+                color: Colors.transparent,
+                child: ListTile(
+                  title: Text(
+                    "Start Conversation",
+                    style: Theme.of(context).textTheme.bodyText1
+                        .copyWith(color: Theme.of(context).textTheme.bodyText1.color.withOpacity(0.5)),
+                  ),
+                  trailing: Icon(
+                    Icons.message,
+                    color: Theme.of(context).textTheme.bodyText1.color.withOpacity(0.5),
+                  ),
+                ),
               ),
             );
-          },
-          child: ListTile(
-            title: Text(
-              "Forward",
-              style: Theme.of(context).textTheme.bodyText1,
-            ),
-            trailing: Icon(
-              Icons.forward,
-              color: Theme.of(context).textTheme.bodyText1.color,
-            ),
-          ),
+          }
         ),
+      FutureBuilder<int>(
+        future: SettingsManager().getMacOSVersion(),
+        builder: (context, snapshot) {
+          return AnimatedSwitcher(
+            duration: Duration(milliseconds: 500),
+            child: snapshot.hasData && snapshot.data < 11 ? Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: () async {
+                  Navigator.pushReplacement(
+                    context,
+                    cupertino.CupertinoPageRoute(
+                      builder: (BuildContext context) {
+                        List<File> existingAttachments = [];
+                        if (!widget.message.isUrlPreview()) {
+                          existingAttachments =
+                              widget.message.attachments.map((attachment) => File(attachment.getPath())).toList();
+                        }
+                        return ConversationView(
+                          isCreator: true,
+                          existingText: widget.message.text,
+                          existingAttachments: existingAttachments,
+                        );
+                      },
+                    ),
+                  );
+                },
+                child: ListTile(
+                  title: Text(
+                    "Forward",
+                    style: Theme.of(context).textTheme.bodyText1,
+                  ),
+                  trailing: Icon(
+                    Icons.forward,
+                    color: Theme.of(context).textTheme.bodyText1.color,
+                  ),
+                ),
+              ),
+            ) : Material(
+              color: Colors.transparent,
+              child: ListTile(
+                title: Text(
+                  "Forward",
+                  style: Theme.of(context).textTheme.bodyText1
+                      .copyWith(color: Theme.of(context).textTheme.bodyText1.color.withOpacity(0.5)),
+                ),
+                trailing: Icon(
+                  Icons.forward,
+                  color: Theme.of(context).textTheme.bodyText1.color.withOpacity(0.5),
+                ),
+              ),
+            ),
+          );
+        }
       ),
       Material(
         color: Colors.transparent,

--- a/lib/managers/settings_manager.dart
+++ b/lib/managers/settings_manager.dart
@@ -42,6 +42,7 @@ class SettingsManager {
   FCMData fcmData;
   List<ThemeObject> themes;
   String countryCode;
+  int _macOSVersion;
 
   int get compressionQuality {
     if (settings.lowMemoryMode) {
@@ -165,5 +166,13 @@ class SettingsManager {
 
   void dispose() {
     _stream.close();
+  }
+
+  FutureOr<int> getMacOSVersion() async {
+    if (_macOSVersion == null) {
+      var res = await SocketManager().sendMessage("get-server-metadata", {}, (_) {});
+      _macOSVersion = int.tryParse(res['data']['os_version'].split(".")[0]);
+    }
+    return _macOSVersion;
   }
 }


### PR DESCRIPTION
Fixes #929.

Applies opacity to FAB on conversation list, and disables pressing the "start conversation" and "forward" items in the menu options.

"Forward" is disabled because we can't (atm) prevent users from sending forwarded messages to people they don't already have a chat with.