### PR TITLE
Fix image placeholder not showing

### DIFF
--- a/lib/layouts/widgets/message_widget/message_content/media_players/image_widget.dart
+++ b/lib/layouts/widgets/message_widget/message_content/media_players/image_widget.dart
@@ -127,14 +127,15 @@ class _ImageWidgetState extends State<ImageWidget> with TickerProviderStateMixin
                 data!,
                 frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
                   if (wasSynchronouslyLoaded) return child;
-                  if (data == null) return buildPlaceHolder();
-
-                  return AnimatedOpacity(
-                    opacity: (frame == null && widget.attachment.guid != "redacted-mode-demo-attachment") ? 0 : 1,
-                    child: child,
-                    duration: const Duration(milliseconds: 250),
-                    curve: Curves.easeInOut,
-                  );
+                  return Stack(children: [
+                    buildPlaceHolder(),
+                    AnimatedOpacity(
+                      opacity: (frame == null && widget.attachment.guid != "redacted-mode-demo-attachment") ? 0 : 1,
+                      child: child,
+                      duration: const Duration(milliseconds: 250),
+                      curve: Curves.easeInOut,
+                    )
+                  ]);
                 },
               )
             : buildPlaceHolder(),


### PR DESCRIPTION
Potentially fixes the issue, we had a redundant condition inside the frameBuilder. Adding `data == null` to show the circular loader should be enough, we can still show the stack there that way there is a placeholder when needed.