### PR TITLE
Improve image placeholder to be closer to the size of the actual image

### DIFF
--- a/lib/layouts/widgets/message_widget/message_content/media_players/image_widget.dart
+++ b/lib/layouts/widgets/message_widget/message_content/media_players/image_widget.dart
@@ -158,11 +158,11 @@ class _ImageWidgetState extends State<ImageWidget> with TickerProviderStateMixin
                     valueColor: new AlwaysStoppedAnimation<Color>(Theme.of(context).primaryColor)))),
       );
     } else {
-      if ((widget.attachment.width!.toDouble() / widget.attachment.height!.toDouble()).isNaN)
+      if (((widget.attachment.width?.toDouble() ?? 0) / (widget.attachment.height?.toDouble() ?? 0)).isNaN)
           return Container(
             padding: EdgeInsets.all(5),
-            width: isLoaded ? widget.attachment.width!.toDouble() : null,
-            height: isLoaded ? widget.attachment.height!.toDouble() : 150,
+            width: widget.attachment.width?.toDouble(),
+            height: widget.attachment.height?.toDouble() ?? 150,
             child: ClipRRect(
               borderRadius: BorderRadius.circular(20),
               child: Container(
@@ -174,12 +174,12 @@ class _ImageWidgetState extends State<ImageWidget> with TickerProviderStateMixin
             ),
           );
       return AspectRatio(
-        aspectRatio: isLoaded ? (widget.attachment.width!.toDouble() / widget.attachment.height!.toDouble()).abs()
-            : context.width / context.height,
+        aspectRatio: ((widget.attachment.width?.toDouble() ?? context.width) /
+            (widget.attachment.height?.toDouble() ?? context.height)).abs(),
         child: Container(
           padding: EdgeInsets.all(5),
-          width: isLoaded ? widget.attachment.width!.toDouble() : null,
-          height: isLoaded ? widget.attachment.height!.toDouble() : 150,
+          width: widget.attachment.width?.toDouble(),
+          height: widget.attachment.height?.toDouble() ?? 150,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(20),
             child: Container(


### PR DESCRIPTION
Fixes #1203, it isn't perfect but its definitely a lot better, screenshot placeholders have a much larger size to prevent a giant jump when they load in