### PR TITLE
Stop url regex from recognizing emails. Support more urls. Ensure url…

### DIFF
--- a/lib/helpers/utils.dart
+++ b/lib/helpers/utils.dart
@@ -367,7 +367,7 @@ Future<MemoryImage?> loadAvatar(Chat chat, Handle? handle) async {
 
 List<RegExpMatch> parseLinks(String text) {
   RegExp exp = new RegExp(
-      r"(?:(?:(?:[Hh][Tt])|[Ff])[Tt][Pp](?:[Ss]?)://)?(?:www.|\S)\S+\.[a-zA-Z]{2,6}(?::[0-9]{1,5})*(?:/(?:$|[a-zA-Z0-9.,;?'\\+&amp;%$#=~_/:-]+))*");
+      r"(?<=\W|^)(?<!\S)(?:(?:(?:[Hh][Tt])|[Ff])[Tt][Pp](?:[Ss]?)://)?(?:(?:www\.)|(?:[a-zA-Z0-9]*))[a-zA-Z0-9\-.]*(?:\.[a-zA-Z0-9]{1,6})(?::[0-9]{1,5})*(?:/(?:$|\S+))*(?=\W|$)");
   return exp.allMatches(text).toList();
 }
 


### PR DESCRIPTION
… starts and ends without whitespace.